### PR TITLE
Add Gmail authentication and quiz attempt history

### DIFF
--- a/100-questoes-2023.html
+++ b/100-questoes-2023.html
@@ -1573,5 +1573,6 @@
 
     window.onload = init;
   </script>
+  <script src="auth.js"></script>
 </body>
 </html>

--- a/100-questoes-2024.html
+++ b/100-questoes-2024.html
@@ -1573,5 +1573,6 @@
 
     window.onload = init;
   </script>
+  <script src="auth.js"></script>
 </body>
 </html>

--- a/25-questoes-2023.html
+++ b/25-questoes-2023.html
@@ -1693,5 +1693,6 @@
 
     init();
   </script>
+  <script src="auth.js"></script>
 </body>
 </html>

--- a/25-questoes-2024.html
+++ b/25-questoes-2024.html
@@ -1692,5 +1692,6 @@
 
     init();
   </script>
+  <script src="auth.js"></script>
 </body>
 </html>

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,111 @@
+const CLIENT_ID = 'YOUR_GOOGLE_CLIENT_ID';
+
+function decodeJwtResponse(token) {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const jsonPayload = decodeURIComponent(
+    atob(base64)
+      .split('')
+      .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+      .join('')
+  );
+  return JSON.parse(jsonPayload);
+}
+
+function handleCredentialResponse(response) {
+  const data = decodeJwtResponse(response.credential);
+  const user = {
+    name: data.name,
+    email: data.email,
+    picture: data.picture,
+  };
+  localStorage.setItem('user', JSON.stringify(user));
+  updateAuthUI();
+}
+
+function getUser() {
+  try {
+    return JSON.parse(localStorage.getItem('user'));
+  } catch {
+    return null;
+  }
+}
+
+function initGoogle() {
+  if (!window.google || !google.accounts || !google.accounts.id) return;
+  google.accounts.id.initialize({
+    client_id: CLIENT_ID,
+    callback: handleCredentialResponse,
+  });
+  updateAuthUI();
+}
+
+function updateAuthUI() {
+  const user = getUser();
+  const container = document.getElementById('signin-container');
+  const historyLink = document.getElementById('history-link');
+  if (historyLink) historyLink.style.display = user ? 'block' : 'none';
+  if (!container) return;
+
+  if (user) {
+    container.innerHTML = `<img src="${user.picture}" alt="${user.name}" style="width:32px;border-radius:50%;margin-right:8px;"> <span>${user.name}</span> <button id="signout">Sair</button>`;
+    const btn = document.getElementById('signout');
+    btn.onclick = () => {
+      if (window.google && google.accounts && google.accounts.id) {
+        google.accounts.id.disableAutoSelect();
+      }
+      localStorage.removeItem('user');
+      updateAuthUI();
+    };
+  } else {
+    container.innerHTML = '';
+    if (window.google && google.accounts && google.accounts.id) {
+      google.accounts.id.renderButton(container, { theme: 'outline', size: 'large' });
+    } else {
+      container.textContent = 'Carregando...';
+    }
+  }
+}
+
+function saveAttempt(qNum, area, selected, correct) {
+  const user = getUser();
+  if (!user) return;
+  const key = `history_${user.email}`;
+  const history = JSON.parse(localStorage.getItem(key)) || [];
+  history.push({
+    timestamp: new Date().toISOString(),
+    qNum,
+    area,
+    selected,
+    correct,
+  });
+  localStorage.setItem(key, JSON.stringify(history));
+}
+
+function getHistory() {
+  const user = getUser();
+  if (!user) return [];
+  const key = `history_${user.email}`;
+  return JSON.parse(localStorage.getItem(key)) || [];
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (typeof window.checkAnswer === 'function') {
+    const original = window.checkAnswer;
+    window.checkAnswer = function (selected) {
+      original(selected);
+      try {
+        const filtered =
+          window.currentArea === 'all'
+            ? window.questions
+            : window.questions.filter(q => q.area === window.currentArea);
+        const q = filtered[window.idx];
+        saveAttempt(q.numero, q.area, selected, selected === q.correct);
+      } catch (e) {
+        console.error('Erro ao salvar tentativa', e);
+      }
+    };
+  }
+  updateAuthUI();
+});
+

--- a/history.html
+++ b/history.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Histórico de Tentativas</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: Arial, sans-serif;
+      background-color: #0e1a2b;
+      color: #ffffff;
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+      min-height: 100vh;
+      padding: 20px;
+    }
+    .container {
+      width: 100%;
+      max-width: 800px;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th, td {
+      border: 1px solid #244063;
+      padding: 8px;
+      text-align: left;
+    }
+    th {
+      background: #183153;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div id="signin-container" style="margin-bottom:20px;"></div>
+    <h1>Histórico de Tentativas</h1>
+    <table id="history-table">
+      <thead>
+        <tr><th>Data</th><th>Área</th><th>Questão</th><th>Resposta</th><th>Correta?</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+  <script src="auth.js"></script>
+  <script src="https://accounts.google.com/gsi/client" async defer onload="initGoogle()"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const tbody = document.querySelector('#history-table tbody');
+      const history = getHistory();
+      history.forEach(h => {
+        const tr = document.createElement('tr');
+        const date = new Date(h.timestamp).toLocaleString();
+        tr.innerHTML = `<td>${date}</td><td>${h.area}</td><td>${h.qNum}</td><td>${h.selected}</td><td>${h.correct ? '✔️' : '❌'}</td>`;
+        tbody.appendChild(tr);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -93,6 +93,8 @@
 </head>
 <body>
   <div class="container">
+    <div id="signin-container" style="margin-bottom:20px;"></div>
+    <button id="history-link" style="display:none;margin-bottom:20px;" onclick="window.location.href='history.html'">📚 Histórico de Tentativas</button>
 
     <div class="dropdown" onclick="toggleDropdown(this)">
       <button>👩‍⚕️ AMRIGS 2024</button>
@@ -137,5 +139,7 @@
       }
     });
   </script>
+  <script src="auth.js"></script>
+  <script src="https://accounts.google.com/gsi/client" async defer onload="initGoogle()"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate Google Identity-based sign-in and sign-out
- track quiz answers per user and save them in browser storage
- add history page to review past attempts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f9e6efcc832ca23371c83841f449